### PR TITLE
Adds stop all sounds playing

### DIFF
--- a/src/containers/Map/MapContainer.jsx
+++ b/src/containers/Map/MapContainer.jsx
@@ -9,7 +9,7 @@ import { MIN_ZOOM, MAX_ZOOM, PLAY_ON_HOVER_SHORTCUT_KEYCODE } from 'constants';
 import { displaySystemMessage } from '../MessagesBox/actions';
 import { updateMapPosition } from './actions';
 import { setSoundCurrentlyLearnt } from '../Midi/actions';
-import { deselectAllSounds } from '../Sounds/actions';
+import { deselectAllSounds, stopAllSoundsPlaying } from '../Sounds/actions';
 import { hideModal } from '../SoundInfo/actions';
 import Space from '../Spaces/SpaceContainer';
 import SoundInfoContainer from '../SoundInfo/SoundInfoContainer';
@@ -18,6 +18,7 @@ import { setShouldPlayOnHover } from '../Settings/actions';
 
 const propTypes = {
   deselectAllSounds: PropTypes.func,
+  stopAllSoundsPlaying: PropTypes.func,
   paths: PropTypes.array,
   spaces: PropTypes.array,
   map: PropTypes.shape({
@@ -76,6 +77,7 @@ class MapContainer extends React.Component {
     if (evt.target.tagName !== 'circle') {
       // deselect all sounds when not clicking on a circle
       this.props.deselectAllSounds();
+      this.props.stopAllSoundsPlaying();
       // turn off current midi learn
       this.props.setSoundCurrentlyLearnt();
       this.props.hideModal();
@@ -144,6 +146,7 @@ export default connect(mapStateToProps, {
   displaySystemMessage,
   updateMapPosition,
   deselectAllSounds,
+  stopAllSoundsPlaying,
   setSoundCurrentlyLearnt,
   hideModal,
   setShouldPlayOnHover,

--- a/src/containers/Sounds/MapCircleContainer.jsx
+++ b/src/containers/Sounds/MapCircleContainer.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import MapCircle from 'components/Sounds/MapCircle';
 import { playAudio, stopAudio } from '../Audio/actions';
@@ -10,18 +9,20 @@ import { isSoundInsideScreen } from './utils';
 import { makeIsSoundSelected } from './selectors';
 
 const propTypes = {
-  sound: PropTypes.object,
-  isThumbnail: PropTypes.bool,
-  shouldPlayOnHover: PropTypes.bool,
-  isSelected: PropTypes.bool,
-  playAudio: PropTypes.func,
-  stopAudio: PropTypes.func,
-  selectSound: PropTypes.func,
-  deselectSound: PropTypes.func,
-  deselectAllSounds: PropTypes.func,
-  toggleHoveringSound: PropTypes.func,
-  openModalForSound: PropTypes.func,
-  hideModal: PropTypes.func,
+  sound: React.PropTypes.object,
+  isThumbnail: React.PropTypes.bool,
+  shouldPlayOnHover: React.PropTypes.bool,
+  isSelected: React.PropTypes.bool,
+  playAudio: React.PropTypes.func,
+  stopAudio: React.PropTypes.func,
+  selectSound: React.PropTypes.func,
+  selectedSounds: React.PropTypes.array,
+  deselectSound: React.PropTypes.func,
+  deselectAllSounds: React.PropTypes.func,
+  toggleHoveringSound: React.PropTypes.func,
+  openModalForSound: React.PropTypes.func,
+  hideModal: React.PropTypes.func,
+  soundInfoModal: React.PropTypes.object,
 };
 
 const isSoundVisible = (props) => {
@@ -63,18 +64,27 @@ class MapCircleContainer extends React.PureComponent {
   }
 
   onClick() {
+    // play and stop sound
     if (this.props.sound.isPlaying) {
       this.props.stopAudio(this.props.sound);
-    } else {
+    } else if (!this.props.isSelected) {
       this.props.playAudio(this.props.sound);
     }
-    if (this.props.sound.isSelected) {
-      this.props.hideModal();
-      this.props.deselectSound();
+    if (this.props.isSelected) {
+      // toggle selecion
+      this.props.deselectSound(this.props.sound.id);
+
+      // hide modal only if it is the one of the last clicked sound
+      if (this.props.soundInfoModal.isVisible
+        && this.props.soundInfoModal.soundID === this.props.sound.id) {
+        this.props.hideModal();
+      }
     } else {
-      this.props.deselectAllSounds();
-      this.props.openModalForSound(this.props.sound);
+      // toggle selection
       this.props.selectSound(this.props.sound.id);
+
+      // open modal if sound is not yet selected
+        this.props.openModalForSound(this.props.sound);
     }
   }
 
@@ -107,10 +117,14 @@ const makeMapStateToProps = (_, ownProps) => {
   const isSoundSelected = makeIsSoundSelected(soundID);
   return (state) => {
     const sound = state.sounds.byID[soundID];
+    const selectedSounds = state.sounds.selectedSounds;
+    const soundInfoModal = state.sounds.soundInfoModal;
     const { shouldPlayOnHover } = state.settings;
     const isSelected = isSoundSelected(state);
     return {
       sound,
+      selectedSounds,
+      soundInfoModal,
       isThumbnail,
       shouldPlayOnHover,
       isSelected,

--- a/src/containers/Sounds/actions.js
+++ b/src/containers/Sounds/actions.js
@@ -6,6 +6,8 @@ import { displaySystemMessage } from '../MessagesBox/actions';
 import { submitQuery, reshapeReceivedSounds } from '../Search/utils';
 import { setSpaceAsCenter } from '../Spaces/actions';
 import { getTrainedTsne, computePointsPositionInSolution } from './utils';
+import { stopAudio } from '../Audio/actions';
+import { getPropertyArrayOfDictionaryEntries } from '../../utils/objectUtils';
 
 export const FETCH_SOUNDS_REQUEST = 'FETCH_SOUNDS_REQUEST';
 export const FETCH_SOUNDS_SUCCESS = 'FETCH_SOUNDS_SUCCESS';
@@ -44,6 +46,16 @@ export const deselectAllSounds = () => (dispatch, getStore) => {
 
 let clearTimeoutId;
 let progress = 0;
+
+// TODO: buggy -> when playing many sounds by hover, stop does not work on all sounds
+export const stopAllSoundsPlaying = () => (dispatch, getStore) => {
+  const playingSourceNodes = getStore().audio.playingSourceNodes;
+  // Object.keys(playingSourceNodes).forEach(
+  //   idx => dispatch(stopAudio(Number(idx), playingSourceNodes[idx].soundID))
+  // );
+  const playingSounds = getPropertyArrayOfDictionaryEntries(playingSourceNodes, 'soundID');
+  playingSounds.forEach(soundID => dispatch(stopAudio(soundID)));
+};
 
 const updateProgress = (sounds, stepIteration) => (dispatch) => {
   const computedProgress = (stepIteration + 1) / MAX_TSNE_ITERATIONS;

--- a/src/utils/objectUtils.js
+++ b/src/utils/objectUtils.js
@@ -50,3 +50,11 @@ export const pureDeleteObjectKey = (obj, property, leaveKey = false) => {
   return Object.assign(goodObj, {
     [badKey]: pureDeleteObjectKey(obj[badKey], remainingBadKeys, leaveKey) });
 };
+
+export const getPropertyArrayOfDictionaryEntries = (dictionary, propertyName) => {
+  const valueArray = [];
+  Object.keys(dictionary).forEach(
+    key => valueArray.push(readObjectPropertyByPropertyAbsName(dictionary[key], propertyName))
+  );
+  return valueArray;
+};

--- a/src/utils/objectUtils.test.js
+++ b/src/utils/objectUtils.test.js
@@ -19,6 +19,16 @@ describe('object utils', () => {
       expect(utils.readObjectPropertyByPropertyAbsName(x, 'a.1.b')).toEqual(3);
     });
   });
+  describe('getPropertyArrayOfDictionaryEntries', () => {
+    it('correctly returns the array of property values of an dictionary like object', () => {
+      const x = {
+        0: { a: [22, { b: 3 }] },
+        1: { a: [22, { b: 2 }] },
+      };
+      expect(utils.getPropertyArrayOfDictionaryEntries(x, 'a[1].b')).toEqual([3, 2]);
+      expect(utils.getPropertyArrayOfDictionaryEntries(x, 'a.1.b')).toEqual([3, 2]);
+    });
+  });
   describe('pureDeleteObjectKey', () => {
     const testObj = { x: 1, y: { a: 4, b: [3, 4, 5], c: { d: 1 } } };
     deepFreeze(testObj);


### PR DESCRIPTION
I encountered this annoying issue #42 when using playOnHover.
Longer Sounds would only be stoppable by clicking one playing sound after the other.

Now it is synchonized with deselectAllSounds when clicking the empty map.

Unfortunately, when exthausively using the playOnHover feature some state changes seem to be so slow, that not all sounds will reliably stop.
But the majority of them will, so this is a small improvement.