### PR TITLE
Revert "Adds stop all sounds playing"

### DIFF
--- a/src/containers/Sounds/MapCircleContainer.jsx
+++ b/src/containers/Sounds/MapCircleContainer.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import MapCircle from 'components/Sounds/MapCircle';
 import { playAudio, stopAudio } from '../Audio/actions';

--- a/src/containers/Sounds/actions.js
+++ b/src/containers/Sounds/actions.js
@@ -6,8 +6,6 @@ import { displaySystemMessage } from '../MessagesBox/actions';
 import { submitQuery, reshapeReceivedSounds } from '../Search/utils';
 import { setSpaceAsCenter, computeSpaceClusters } from '../Spaces/actions';
 import { getTrainedTsne, computePointsPositionInSolution } from './utils';
-import { stopAudio } from '../Audio/actions';
-import { getPropertyArrayOfDictionaryEntries } from '../../utils/objectUtils';
 
 export const FETCH_SOUNDS_REQUEST = 'FETCH_SOUNDS_REQUEST';
 export const FETCH_SOUNDS_SUCCESS = 'FETCH_SOUNDS_SUCCESS';
@@ -46,16 +44,6 @@ export const deselectAllSounds = () => (dispatch, getStore) => {
 
 let clearTimeoutId;
 let progress = 0;
-
-// TODO: buggy -> when playing many sounds by hover, stop does not work on all sounds
-export const stopAllSoundsPlaying = () => (dispatch, getStore) => {
-  const playingSourceNodes = getStore().audio.playingSourceNodes;
-  // Object.keys(playingSourceNodes).forEach(
-  //   idx => dispatch(stopAudio(Number(idx), playingSourceNodes[idx].soundID))
-  // );
-  const playingSounds = getPropertyArrayOfDictionaryEntries(playingSourceNodes, 'soundID');
-  playingSounds.forEach(soundID => dispatch(stopAudio(soundID)));
-};
 
 const updateProgress = (sounds, stepIteration) => (dispatch) => {
   const computedProgress = (stepIteration + 1) / MAX_TSNE_ITERATIONS;

--- a/src/utils/objectUtils.js
+++ b/src/utils/objectUtils.js
@@ -50,11 +50,3 @@ export const pureDeleteObjectKey = (obj, property, leaveKey = false) => {
   return Object.assign(goodObj, {
     [badKey]: pureDeleteObjectKey(obj[badKey], remainingBadKeys, leaveKey) });
 };
-
-export const getPropertyArrayOfDictionaryEntries = (dictionary, propertyName) => {
-  const valueArray = [];
-  Object.keys(dictionary).forEach(
-    key => valueArray.push(readObjectPropertyByPropertyAbsName(dictionary[key], propertyName))
-  );
-  return valueArray;
-};

--- a/src/utils/objectUtils.test.js
+++ b/src/utils/objectUtils.test.js
@@ -19,16 +19,6 @@ describe('object utils', () => {
       expect(utils.readObjectPropertyByPropertyAbsName(x, 'a.1.b')).toEqual(3);
     });
   });
-  describe('getPropertyArrayOfDictionaryEntries', () => {
-    it('correctly returns the array of property values of an dictionary like object', () => {
-      const x = {
-        0: { a: [22, { b: 3 }] },
-        1: { a: [22, { b: 2 }] },
-      };
-      expect(utils.getPropertyArrayOfDictionaryEntries(x, 'a[1].b')).toEqual([3, 2]);
-      expect(utils.getPropertyArrayOfDictionaryEntries(x, 'a.1.b')).toEqual([3, 2]);
-    });
-  });
   describe('pureDeleteObjectKey', () => {
     const testObj = { x: 1, y: { a: 4, b: [3, 4, 5], c: { d: 1 } } };
     deepFreeze(testObj);


### PR DESCRIPTION
Reverts ffont/freesound-explorer#45 as it generates `Uncaught ReferenceError: PropTypes is not defined` error at load time. We should have automatic tests enabled (which I guess would have caught that).