### PR TITLE
Re-Enables show cluster-tags by keyboard shortcut

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -66,7 +66,7 @@ export const MAP_SCALE_FACTOR = 20;
 export const TOGGLE_MULTISELECTION_KEYCODE = 16; // shift key
 export const PLAY_ON_HOVER_SHORTCUT_KEYCODE = 18; // alt key
 export const TOGGLE_SELECTION_MAC_KEYCODE = 91 || 93; // cmd key left /right
-export const TOGGLE_SHOW_CLUSTER_TAGS = 84; // t
+export const TOGGLE_SHOW_CLUSTER_TAGS_KEYCODE = 84; // t
 
 // tsne
 export const MAX_TSNE_ITERATIONS = 150;

--- a/src/containers/Map/MapContainer.jsx
+++ b/src/containers/Map/MapContainer.jsx
@@ -6,7 +6,7 @@ import { connect } from 'react-redux';
 import SpaceTitle from 'components/Spaces/SpaceTitle';
 import 'polyfills/requestAnimationFrame';
 import { MIN_ZOOM, MAX_ZOOM, PLAY_ON_HOVER_SHORTCUT_KEYCODE,
-  TOGGLE_SHOW_CLUSTER_TAGS, TOGGLE_MULTISELECTION_KEYCODE } from 'constants';
+  TOGGLE_SHOW_CLUSTER_TAGS_KEYCODE, TOGGLE_MULTISELECTION_KEYCODE } from 'constants';
 import { displaySystemMessage } from '../MessagesBox/actions';
 import { updateMapPosition } from './actions';
 import { setSoundCurrentlyLearnt } from '../Midi/actions';
@@ -103,9 +103,12 @@ class MapContainer extends React.Component {
       // Turn play sounds on hover off
       this.props.setShouldPlayOnHover(false);
     }
-      if (evt.keyCode === TOGGLE_MULTISELECTION_KEYCODE) {
-        this.props.toggleMultiSelection(false);
-      }
+    if (evt.keyCode === TOGGLE_MULTISELECTION_KEYCODE) {
+      this.props.toggleMultiSelection(false);
+    }
+    if (evt.keyCode === TOGGLE_SHOW_CLUSTER_TAGS_KEYCODE) {
+      this.props.toggleClusterTags();
+    }
   }
 
   zoomHandler() {

--- a/src/containers/Settings/reducer.test.js
+++ b/src/containers/Settings/reducer.test.js
@@ -24,9 +24,9 @@ describe('settings reducer', () => {
   it('correctly sets shouldShowClusterTags setting', () => {
     const stateBefore = { shouldShowClusterTags: false };
     const stateAfter = { shouldShowClusterTags: true };
-    expect(reducer(stateBefore, toggleClusterTags(true)))
+    expect(reducer(stateBefore, toggleClusterTags()))
       .toEqual(stateAfter);
-    expect(reducer(stateAfter, toggleClusterTags(false)))
+    expect(reducer(stateAfter, toggleClusterTags()))
       .toEqual(stateBefore);
   });
 });


### PR DESCRIPTION
Cleans up the last bug in this feature