### PR TITLE
Api sorting

### DIFF
--- a/src/components/Input/SelectWithLabel.scss
+++ b/src/components/Input/SelectWithLabel.scss
@@ -2,17 +2,17 @@
 @import "../../stylesheets/mixins";
 
 .select-with-label {
-  margin: 15px 0 30px;
+  margin: 15px 0 15px;
   label, select {
     display: inline-block;
-    height: $sidebarClosedOffset;
+    height: $sidebarClosedOffset - 10px ;
     vertical-align: middle;
   }
   select {
     @include base-focus;
     background-color: white;
     color: $blackBackground;
-    width: 40%;
+    width: 60%;
     float: right;
     border-radius: $defaultBorderRadius;
     span {

--- a/src/components/Spaces/SpaceTitle.jsx
+++ b/src/components/Spaces/SpaceTitle.jsx
@@ -13,6 +13,7 @@ const propTypes = {
     maxDuration: PropTypes.number,
     minDuration: PropTypes.number,
     descriptor: PropTypes.string,
+    sorting: PropTypes.string,
   }),
   sounds: PropTypes.array,
   isThumbnail: PropTypes.bool,
@@ -35,6 +36,43 @@ class SpaceTitle extends React.Component {
     if (!this.props.sounds.length) {
       return null;
     }
+
+    function makeSortingLabel(sortstr) {
+      let label;
+      switch (sortstr) {
+        case 'score': {
+          label = 'Relevance';
+          break;
+        }
+        case 'rating_desc': {
+          label = 'Rating';
+          break;
+        }
+        case 'duration_desc': {
+          label = 'Duration';
+          break;
+        }
+        case 'downloads_desc': {
+          label = 'Downloads';
+          break;
+        }
+        case 'creation_desc': {
+          label = 'newest first';
+          break;
+        }
+        case 'creation_asc': {
+          label = 'oldest first';
+          break;
+        }
+        default: {
+          label = 'Releveance';
+          break;
+        }
+      }
+      return label;
+    }
+
+
     return (
       <div
         className={`SpaceTitle${this.props.isThumbnail ? ' thumbnail' : ''}`}
@@ -47,6 +85,10 @@ class SpaceTitle extends React.Component {
             (this.props.queryParams.descriptor) === 'lowlevel.mfcc.mean' ? 'Timbre' : 'Tonality'}
           </li>
           <li>Duration: {this.props.queryParams.minDuration} to {this.props.queryParams.maxDuration} s</li>
+          <li>
+            Sorted by {
+              (makeSortingLabel(this.props.queryParams.sorting))
+            }</li>
         </ol>
       </div>);
   }

--- a/src/containers/Search/SearchContainer.jsx
+++ b/src/containers/Search/SearchContainer.jsx
@@ -5,7 +5,7 @@ import { DEFAULT_QUERY, PERFORM_QUERY_AT_MOUNT } from 'constants';
 import InputTextButton from 'components/Input/InputTextButton';
 import SelectWithLabel from 'components/Input/SelectWithLabel';
 import SliderRange from 'components/Input/SliderRange';
-import { updateDescriptor, updateMinDuration, updateMaxDuration,
+import { updateSorting, updateDescriptor, updateMinDuration, updateMaxDuration,
   updateMaxResults, updateQuery }
   from './actions';
 import { getSounds } from '../Sounds/actions';
@@ -15,10 +15,12 @@ const propTypes = {
   maxResults: PropTypes.number,
   maxDuration: PropTypes.number,
   minDuration: PropTypes.number,
+  sorting: PropTypes.string,
   query: PropTypes.string,
   descriptor: PropTypes.string,
   getSounds: PropTypes.func,
   isExampleQueryDone: PropTypes.bool,
+  updateSorting: PropTypes.func,
   updateDescriptor: PropTypes.func,
   updateMinDuration: PropTypes.func,
   updateMaxDuration: PropTypes.func,
@@ -54,8 +56,8 @@ class QueryBox extends React.Component {
 
   submitQuery() {
     let { query } = this.props;
-    const { descriptor, maxResults, minDuration, maxDuration } = this.props;
-    const queryParams = { descriptor, maxResults, minDuration, maxDuration };
+    const { sorting, descriptor, maxResults, minDuration, maxDuration } = this.props;
+    const queryParams = { sorting, descriptor, maxResults, minDuration, maxDuration };
     if (!query.length) {
       query = DEFAULT_QUERY;
     }
@@ -92,6 +94,23 @@ class QueryBox extends React.Component {
           label="Arrange by"
           tabIndex="0"
           defaultValue={this.props.descriptor}
+        />
+        <SelectWithLabel
+          onChange={(evt) => {
+            const sorting = evt.target.value;
+            this.props.updateSorting(sorting);
+          }}
+          options={[
+            { value: 'score', name: 'Relevance' },
+            { value: 'rating_desc', name: 'Rating' },
+            { value: 'duration_desc', name: 'Duration' },
+            { value: 'downloads_desc', name: 'Downloads' },
+            { value: 'creation_desc', name: 'Creation Date (newest first)' },
+            { value: 'creation_asc', name: 'Creation Date (oldest first)' },
+          ]}
+          label="Sort by"
+          tabIndex="0"
+          defaultValue={this.props.sorting}
         />
         <SliderRange
           label="Number of results"
@@ -133,6 +152,7 @@ export default connect(mapStateToProps, {
   getSounds,
   setExampleQueryDone,
   updateDescriptor,
+  updateSorting,
   updateMinDuration,
   updateMaxDuration,
   updateMaxResults,

--- a/src/containers/Search/actions.js
+++ b/src/containers/Search/actions.js
@@ -4,10 +4,12 @@ export const UPDATE_MAX_RESULTS = 'UPDATE_MAX_RESULTS';
 export const UPDATE_MAX_DURATION = 'UPDATE_MAX_DURATION';
 export const UPDATE_MIN_DURATION = 'UPDATE_MIN_DURATION';
 export const UPDATE_DESCRIPTOR = 'UPDATE_DESCRIPTOR';
+export const UPDATE_SORTING = 'UPDATE_SORTING';
 export const UPDATE_QUERY = 'UPDATE_QUERY';
 
 export const updateMinDuration = makeActionCreator(UPDATE_MIN_DURATION, 'minDuration');
 export const updateMaxDuration = makeActionCreator(UPDATE_MAX_DURATION, 'maxDuration');
 export const updateMaxResults = makeActionCreator(UPDATE_MAX_RESULTS, 'maxResults');
 export const updateDescriptor = makeActionCreator(UPDATE_DESCRIPTOR, 'descriptor');
+export const updateSorting = makeActionCreator(UPDATE_SORTING, 'sorting');
 export const updateQuery = makeActionCreator(UPDATE_QUERY, 'query');

--- a/src/containers/Search/reducer.js
+++ b/src/containers/Search/reducer.js
@@ -1,7 +1,7 @@
 import { DEFAULT_MAX_DURATION, DEFAULT_DESCRIPTOR, DEFAULT_MAX_RESULTS,
-  DEFAULT_MIN_DURATION }
+  DEFAULT_MIN_DURATION, DEFAULT_SORTING }
   from 'constants';
-import { UPDATE_DESCRIPTOR, UPDATE_MAX_RESULTS, UPDATE_MIN_DURATION,
+import { UPDATE_SORTING, UPDATE_DESCRIPTOR, UPDATE_MAX_RESULTS, UPDATE_MIN_DURATION,
   UPDATE_MAX_DURATION, UPDATE_QUERY }
   from './actions';
 import { FETCH_SOUNDS_REQUEST, FETCH_SOUNDS_FAILURE, MAP_COMPUTATION_COMPLETE }
@@ -14,6 +14,7 @@ export const initialState = {
   minDuration: DEFAULT_MIN_DURATION,
   maxDuration: DEFAULT_MAX_DURATION,
   descriptor: DEFAULT_DESCRIPTOR,
+  sorting: DEFAULT_SORTING,
 };
 
 const search = (state = initialState, action) => {
@@ -21,6 +22,11 @@ const search = (state = initialState, action) => {
     case UPDATE_DESCRIPTOR: {
       return Object.assign({}, state, {
         descriptor: action.descriptor,
+      });
+    }
+    case UPDATE_SORTING: {
+      return Object.assign({}, state, {
+        sorting: action.sorting,
       });
     }
     case UPDATE_MAX_RESULTS: {

--- a/src/containers/Sounds/actions.js
+++ b/src/containers/Sounds/actions.js
@@ -106,8 +106,8 @@ export const getSounds = (query, queryParams) => (dispatch, getStore) => {
   dispatch(displaySystemMessage('Searching for sounds...'));
   const queryID = UUID.v4();
   dispatch(fetchRequest(queryID, query, queryParams));
-  const { maxResults, maxDuration } = queryParams;
-  submitQuery(query, maxResults, maxDuration).then(
+  const { maxResults, maxDuration, sorting } = queryParams;
+  submitQuery(query, maxResults, maxDuration, sorting).then(
     (allPagesResults) => {
       const sounds = reshapeReceivedSounds(allPagesResults, queryID);
       const soundsFound = Object.keys(sounds).length;


### PR DESCRIPTION
Adresses issue #53:

Adds a quick possibility of pre-filtering the freesound query result.
It simply uses the Freesound API "sort" parameter.

Looks like this:
<img width="748" alt="screenshot 2018-05-03 14 22 32" src="https://user-images.githubusercontent.com/19167028/39576144-6fdc65ce-4edd-11e8-99f0-3c8d6a9ddbb2.png">
 