### PR TITLE
Fixes clustertag issue #59

### DIFF
--- a/src/containers/Spaces/actions.js
+++ b/src/containers/Spaces/actions.js
@@ -16,7 +16,7 @@ export const setSpaceAsCenter = (space) => {
 };
 
 const removeSpaceAction = makeActionCreator(REMOVE_SPACE, 'queryID');
-const clustersComputed = makeActionCreator(CLUSTERS_COMPUTED, 'clusters');
+const clustersComputed = makeActionCreator(CLUSTERS_COMPUTED, 'queryID', 'clusters');
 
 export const removeSpace = space => (dispatch) => {
   dispatch(removeSpaceAction(space.queryID));
@@ -35,6 +35,6 @@ export const computeSpaceClusters = queryID => (dispatch, getStore) => {
   const sounds = {};
   space.sounds.forEach(soundID => sounds[soundID] = allsounds[soundID]);
   computeClustersFromTsnePos(sounds, space, mapPosition)
-  .then(clusters => dispatch(clustersComputed(clusters)));
+  .then(clusters => dispatch(clustersComputed(space.queryID, clusters)));
 };
 

--- a/src/containers/Spaces/reducer.js
+++ b/src/containers/Spaces/reducer.js
@@ -87,8 +87,11 @@ export const singleSpace = (state = spaceInitialState, action, spaceIndex) => {
       });
     }
     case CLUSTERS_COMPUTED: {
-      const { clusters } = action;
-      return Object.assign({}, state, { clusters });
+      const { queryID, clusters } = action;
+      if (state.queryID === queryID) {
+        return Object.assign({}, state, { clusters });
+      }
+      return state;
     }
     default:
       return state;


### PR DESCRIPTION
I solved the cluster tag overwirte issue of #59.
A unique ID for the space to equip with clusters was missing.
So when you zoom out to see all spaces, the current space changed and others where affected.