### PR TITLE
Immideate info about number of sounds for the entered query terms

### DIFF
--- a/src/containers/Search/SearchContainer.jsx
+++ b/src/containers/Search/SearchContainer.jsx
@@ -1,16 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { DEFAULT_QUERY, PERFORM_QUERY_AT_MOUNT } from 'constants';
+import { PERFORM_QUERY_AT_MOUNT } from 'constants';
 import InputTextButton from 'components/Input/InputTextButton';
 import SelectWithLabel from 'components/Input/SelectWithLabel';
 import SliderRange from 'components/Input/SliderRange';
 import { updateSorting, updateDescriptor, updateMinDuration, updateMaxDuration,
   updateMaxResults, updateQuery }
   from './actions';
-import { getSounds } from '../Sounds/actions';
+import { getSounds, getResultsCount } from '../Sounds/actions';
 import { setExampleQueryDone } from '../Sidebar/actions';
 import { randomQuery } from '../../utils/randomUtils';
+
 
 const propTypes = {
   maxResults: PropTypes.number,
@@ -20,6 +21,7 @@ const propTypes = {
   query: PropTypes.string,
   descriptor: PropTypes.string,
   getSounds: PropTypes.func,
+  getResultsCount: PropTypes.func,
   isExampleQueryDone: PropTypes.bool,
   updateSorting: PropTypes.func,
   updateDescriptor: PropTypes.func,
@@ -65,6 +67,13 @@ class QueryBox extends React.Component {
     this.props.getSounds(query, queryParams);
   }
 
+  // TODO: make request for getting number of results
+  // getNumOfResults() {
+  //   let { query } = this.props;
+  //   const page_size = 1;
+
+  // }
+
   render() {
     return (
       <form
@@ -79,6 +88,8 @@ class QueryBox extends React.Component {
           onTextChange={(evt) => {
             const query = evt.target.value;
             this.props.updateQuery(query);
+            // makes a reqest to freesound for each keystroke to get number of possible results
+            this.props.getResultsCount(query);
           }}
           currentValue={this.props.query}
           tabIndex="0"
@@ -151,6 +162,7 @@ const mapStateToProps = (state) => {
 QueryBox.propTypes = propTypes;
 export default connect(mapStateToProps, {
   getSounds,
+  getResultsCount,
   setExampleQueryDone,
   updateDescriptor,
   updateSorting,

--- a/src/containers/Search/SearchContainer.jsx
+++ b/src/containers/Search/SearchContainer.jsx
@@ -5,6 +5,7 @@ import { PERFORM_QUERY_AT_MOUNT } from 'constants';
 import InputTextButton from 'components/Input/InputTextButton';
 import SelectWithLabel from 'components/Input/SelectWithLabel';
 import SliderRange from 'components/Input/SliderRange';
+import { debounce } from 'lodash';
 import { updateSorting, updateDescriptor, updateMinDuration, updateMaxDuration,
   updateMaxResults, updateQuery }
   from './actions';
@@ -37,6 +38,14 @@ class QueryBox extends React.Component {
     super(props);
     this.submitQuery = this.submitQuery.bind(this);
     this.tryQueryAtMount = this.tryQueryAtMount.bind(this);
+  }
+
+  componentWillMount() {
+    // prevents too many requests to FS server
+    this._debouncedResultsCount = debounce(this.props.getResultsCount.bind(this), 400, {
+      leading: false,
+      trailing: true,
+    });
   }
 
   componentDidMount() {
@@ -82,7 +91,7 @@ class QueryBox extends React.Component {
             const query = evt.target.value;
             this.props.updateQuery(query);
             // makes a reqest to freesound for each keystroke to get number of possible results
-            this.props.getResultsCount(query);
+            this._debouncedResultsCount(query);
           }}
           currentValue={this.props.query}
           tabIndex="0"

--- a/src/containers/Search/SearchContainer.jsx
+++ b/src/containers/Search/SearchContainer.jsx
@@ -67,13 +67,6 @@ class QueryBox extends React.Component {
     this.props.getSounds(query, queryParams);
   }
 
-  // TODO: make request for getting number of results
-  // getNumOfResults() {
-  //   let { query } = this.props;
-  //   const page_size = 1;
-
-  // }
-
   render() {
     return (
       <form

--- a/src/containers/Search/utils.js
+++ b/src/containers/Search/utils.js
@@ -46,6 +46,17 @@ function search(query = randomQuery(), filter = '', maxResults = DEFAULT_MAX_RES
   return Promise.all(promises);
 }
 
+// simplified search reduced to get just the count property
+export function miniSearch(query) {
+  const pageSize = 1;
+  const promises = [];
+  freesound.setToken(sessionStorage.getItem('appToken'));
+  promises.push(freesound.textSearch(query, {
+    page_size: pageSize,
+  }));
+  return Promise.all(promises);
+}
+
 export function submitQuery(submittedQuery, maxResults, maxDuration, sorting) {
   let query;
   let filter = '';

--- a/src/containers/Sounds/actions.js
+++ b/src/containers/Sounds/actions.js
@@ -146,8 +146,10 @@ export const getResultsCount = query => dispatch => {
     response => {
       dispatch(displaySystemMessage(`Possible number of results: ${response[0].count}`, MESSAGE_STATUS.INFO));
     },
-    (error) => {
-      dispatch(displaySystemMessage('No sounds available for this query.', MESSAGE_STATUS.ERROR));
+    error => {
+      if (error === 'Unknown Status Code') {
+        dispatch(displaySystemMessage('Too many requests to server, please wait a few seconds.', MESSAGE_STATUS.ERROR));
+      }
     }
 );
 };

--- a/src/containers/Sounds/actions.js
+++ b/src/containers/Sounds/actions.js
@@ -3,7 +3,7 @@ import makeActionCreator from 'utils/makeActionCreator';
 import { MESSAGE_STATUS, MAX_TSNE_ITERATIONS } from 'constants';
 import 'polyfills/requestAnimationFrame';
 import { displaySystemMessage } from '../MessagesBox/actions';
-import { submitQuery, reshapeReceivedSounds } from '../Search/utils';
+import { submitQuery, miniSearch, reshapeReceivedSounds } from '../Search/utils';
 import { setSpaceAsCenter, computeSpaceClusters } from '../Spaces/actions';
 import { getTrainedTsne, computePointsPositionInSolution } from './utils';
 import { stopAudio } from '../Audio/actions';
@@ -139,4 +139,15 @@ export const getSounds = (query, queryParams) => (dispatch, getStore) => {
       dispatch(fetchFailure(error, queryID));
     }
   );
+};
+
+export const getResultsCount = query => dispatch => {
+  miniSearch(query).then(
+    response => {
+      dispatch(displaySystemMessage(`Possible number of results: ${response[0].count}`, MESSAGE_STATUS.INFO));
+    },
+    (error) => {
+      dispatch(displaySystemMessage('No sounds available for this query.', MESSAGE_STATUS.ERROR));
+    }
+);
 };


### PR DESCRIPTION
Here comes a direct feedback to the user for seeing the impact of his query formulation on the number of results.
This Info is displayed in the system message box before submitting the query.

This is a immense improvement, as calculating the map is not abortable and firing a query takes quite long.

Cares for #64 