### PR TITLE
Abort search

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -67,7 +67,7 @@ export const MAP_SCALE_FACTOR = 20;
 export const TOGGLE_MULTISELECTION_KEYCODE = 16; // shift key
 export const PLAY_ON_HOVER_SHORTCUT_KEYCODE = 18; // alt key
 export const TOGGLE_SHOW_CLUSTER_TAGS_KEYCODE = 84; // t
-
+export const CANCEL_KEYCODE = 27; // esc
 // tsne
 export const MAX_TSNE_ITERATIONS = 150;
 export const TSNE_CONFIG = {

--- a/src/containers/Map/MapContainer.jsx
+++ b/src/containers/Map/MapContainer.jsx
@@ -72,7 +72,7 @@ class MapContainer extends React.Component {
   }
 
   componentWillUnmount() {
-    document.removeEventListener('keydown', this.onKeypressCallback, false);
+    document.removeEventListener('keydown', this.onKeydownCallback, false);
     document.removeEventListener('keyup', this.onKeyupCallback, false);
   }
 

--- a/src/containers/Map/MapContainer.jsx
+++ b/src/containers/Map/MapContainer.jsx
@@ -6,20 +6,23 @@ import { connect } from 'react-redux';
 import SpaceTitle from 'components/Spaces/SpaceTitle';
 import 'polyfills/requestAnimationFrame';
 import { MIN_ZOOM, MAX_ZOOM, PLAY_ON_HOVER_SHORTCUT_KEYCODE,
-  TOGGLE_SHOW_CLUSTER_TAGS_KEYCODE, TOGGLE_MULTISELECTION_KEYCODE } from 'constants';
+  TOGGLE_SHOW_CLUSTER_TAGS_KEYCODE, TOGGLE_MULTISELECTION_KEYCODE, CANCEL_KEYCODE } from 'constants';
 import { displaySystemMessage } from '../MessagesBox/actions';
 import { updateMapPosition } from './actions';
 import { setSoundCurrentlyLearnt } from '../Midi/actions';
 import { deselectAllSounds, stopAllSoundsPlaying } from '../Sounds/actions';
 import { hideModal } from '../SoundInfo/actions';
 import Space from '../Spaces/SpaceContainer';
+import { getCurrentSpaceObj } from '../Spaces/utils';
+import { removeSpace } from '../Spaces/actions';
 import MapPath from '../Paths/MapPath';
 import { setShouldPlayOnHover, toggleClusterTags, toggleMultiSelection } from '../Settings/actions';
 import SoundInfoContainer from '../SoundInfo/SoundInfoContainer';
 
 const propTypes = {
-  deselectAllSounds: PropTypes.func,
-  stopAllSoundsPlaying: PropTypes.func,
+  isSearchEnabled: PropTypes.bool,
+  currentSpaceObj: PropTypes.object,
+  activeSearches: PropTypes.array,
   paths: PropTypes.array,
   spaces: PropTypes.array,
   map: PropTypes.shape({
@@ -27,6 +30,9 @@ const propTypes = {
     translateY: PropTypes.number,
     scale: PropTypes.number,
   }),
+  removeSpace: PropTypes.func,
+  deselectAllSounds: PropTypes.func,
+  stopAllSoundsPlaying: PropTypes.func,
   setSoundCurrentlyLearnt: PropTypes.func,
   updateMapPosition: PropTypes.func,
   hideModal: PropTypes.func,
@@ -96,6 +102,13 @@ class MapContainer extends React.Component {
     if (evt.keyCode === TOGGLE_MULTISELECTION_KEYCODE) {
       this.props.toggleMultiSelection(true);
     }
+    // only remove space if it is an active search
+    if (
+      evt.keyCode === CANCEL_KEYCODE && this.props.isSearchEnabled
+      && this.props.activeSearches.includes(this.props.currentSpaceObj.queryID)
+    ) {
+      this.props.removeSpace(this.props.currentSpaceObj);
+    }
   }
 
   onKeyupCallback(evt) {
@@ -150,13 +163,16 @@ class MapContainer extends React.Component {
 const mapStateToProps = (state) => {
   const { paths } = state.paths;
   const { spaces } = state.spaces;
+  const currentSpaceObj = getCurrentSpaceObj(spaces, state.spaces.currentSpace);
+  const { isSearchEnabled, activeSearches } = state.search;
   const { map } = state;
-  return { paths, spaces, map };
+  return { paths, spaces, map, currentSpaceObj, isSearchEnabled, activeSearches };
 };
 
 MapContainer.propTypes = propTypes;
 
 export default connect(mapStateToProps, {
+  removeSpace,
   displaySystemMessage,
   updateMapPosition,
   deselectAllSounds,

--- a/src/containers/Search/reducer.js
+++ b/src/containers/Search/reducer.js
@@ -6,10 +6,12 @@ import { UPDATE_SORTING, UPDATE_DESCRIPTOR, UPDATE_MAX_RESULTS, UPDATE_MIN_DURAT
   from './actions';
 import { FETCH_SOUNDS_REQUEST, FETCH_SOUNDS_FAILURE, MAP_COMPUTATION_COMPLETE }
   from '../Sounds/actions';
+import { REMOVE_SPACE } from '../Spaces/actions';
 
 export const initialState = {
   query: '',
-  isSearchEnabled: true,
+  isSearchEnabled: false,
+  activeSearches: [],
   maxResults: DEFAULT_MAX_RESULTS,
   minDuration: DEFAULT_MIN_DURATION,
   maxDuration: DEFAULT_MAX_DURATION,
@@ -49,13 +51,23 @@ const search = (state = initialState, action) => {
         query: action.query,
       });
     }
+    case REMOVE_SPACE:
     case FETCH_SOUNDS_REQUEST:
     case FETCH_SOUNDS_FAILURE:
     case MAP_COMPUTATION_COMPLETE: {
-      return Object.assign({}, state, {
-        // disabled with every new query
-        isSearchEnabled: action.type !== FETCH_SOUNDS_REQUEST,
-      });
+      let activeSearches = [];
+      // copy active searches squentially to avoid testing issues
+      state.activeSearches.forEach(e => activeSearches.push(e));
+      // delete failed or finished searches
+      if (action.type !== FETCH_SOUNDS_REQUEST) {
+        activeSearches = activeSearches.filter((a) => a !== action.queryID);
+      } else {
+        // add new request
+        activeSearches.push(action.queryID);
+      }
+      // search is enabled as long as there is any active one.
+      const isSearchEnabled = activeSearches.length !== 0;
+      return Object.assign({}, state, { activeSearches, isSearchEnabled });
     }
     default:
       return state;

--- a/src/containers/Search/reducer.test.js
+++ b/src/containers/Search/reducer.test.js
@@ -2,6 +2,7 @@ import deepFreeze from 'deep-freeze';
 import { default as reducer, initialState } from './reducer';
 import { updateDescriptor, updateQuery, updateMaxDuration,
   updateMinDuration, updateMaxResults } from './actions';
+import { fetchRequest, MAP_COMPUTATION_COMPLETE, mapComputationComplete } from '../Sounds/actions';
 
 describe('search reducer', () => {
   it('should return initialState', () => {
@@ -46,6 +47,16 @@ describe('search reducer', () => {
     const stateAfter = Object.assign({}, stateBefore, { maxResults: 100 });
     it('correctly updates state', () => {
       expect(reducer(stateBefore, updateMaxResults(maxResults))).toEqual(stateAfter);
+    });
+  });
+  describe('isSearchEnabled', () => {
+    const stateBefore = initialState;
+    const stateAfter = Object.assign({}, stateBefore, { isSearchEnabled: true, activeSearches: ['123'] });
+    it('correctly updates status of enabled searches', () => {
+      expect(reducer(stateBefore, fetchRequest('123', '', ''))).toEqual(stateAfter);
+    });
+    it('correctly resets isSearchEnabled', () => {
+      expect(reducer(stateAfter, mapComputationComplete('123'))).toEqual(stateBefore);
     });
   });
 });

--- a/src/containers/Sounds/actions.js
+++ b/src/containers/Sounds/actions.js
@@ -20,12 +20,12 @@ export const GET_SOUND_BUFFER = 'GET_SOUND_BUFFER';
 export const TOGGLE_HOVERING_SOUND = 'TOGGLE_HOVERING_SOUND';
 export const REMOVE_SOUND = 'REMOVE_SOUND';
 
-// no need to exports all these actions as they will be used internally in getSounds
-const fetchRequest = makeActionCreator(FETCH_SOUNDS_REQUEST, 'queryID', 'query', 'queryParams');
-const fetchSuccess = makeActionCreator(FETCH_SOUNDS_SUCCESS, 'sounds', 'queryID', 'mapPosition');
-const fetchFailure = makeActionCreator(FETCH_SOUNDS_FAILURE, 'error', 'queryID');
-const updateSoundsPosition = makeActionCreator(UPDATE_SOUNDS_POSITION, 'sounds', 'queryID');
-const mapComputationComplete = makeActionCreator(MAP_COMPUTATION_COMPLETE, 'queryID');
+// export needed for testing though all these actions will be only used internally in getSounds
+export const fetchRequest = makeActionCreator(FETCH_SOUNDS_REQUEST, 'queryID', 'query', 'queryParams');
+export const fetchSuccess = makeActionCreator(FETCH_SOUNDS_SUCCESS, 'sounds', 'queryID', 'mapPosition');
+export const fetchFailure = makeActionCreator(FETCH_SOUNDS_FAILURE, 'error', 'queryID');
+export const updateSoundsPosition = makeActionCreator(UPDATE_SOUNDS_POSITION, 'sounds', 'queryID');
+export const mapComputationComplete = makeActionCreator(MAP_COMPUTATION_COMPLETE, 'queryID');
 
 export const selectSound = makeActionCreator(SELECT_SOUND_BY_ID, 'soundID');
 export const deselectSound = makeActionCreator(DESELECT_SOUND_BY_ID, 'soundID');

--- a/src/containers/Spaces/actions.js
+++ b/src/containers/Spaces/actions.js
@@ -1,6 +1,7 @@
 import makeActionCreator from 'utils/makeActionCreator';
 import { removeSound } from '../Sounds/actions';
 import { computeClustersFromTsnePos } from './utils';
+import { displaySystemMessage } from '../MessagesBox/actions';
 
 export const SET_SPACE_AS_CENTER = 'SET_SPACE_AS_CENTER';
 export const REMOVE_SPACE = 'REMOVE_SPACE';
@@ -19,8 +20,10 @@ const removeSpaceAction = makeActionCreator(REMOVE_SPACE, 'queryID');
 const clustersComputed = makeActionCreator(CLUSTERS_COMPUTED, 'queryID', 'clusters');
 
 export const removeSpace = space => (dispatch) => {
-  dispatch(removeSpaceAction(space.queryID));
-  space.sounds.forEach(soundID => dispatch(removeSound(soundID)));
+  const { query, queryID, sounds } = space;
+  dispatch(removeSpaceAction(queryID));
+  sounds.forEach(soundID => dispatch(removeSound(soundID)));
+  dispatch(displaySystemMessage(`Space "${query}" has been deleted.`));
 };
 
 export const computeSpaceClusters = queryID => (dispatch, getStore) => {

--- a/src/containers/Spaces/reducer.js
+++ b/src/containers/Spaces/reducer.js
@@ -124,6 +124,9 @@ export const spacesReducer = (state = initialState.spaces, action) => {
 
 export const currentSpace = (state = initialState.currentSpace, action, allSpaces) => {
   switch (action.type) {
+    case REMOVE_SPACE: {
+      return '';
+    }
     case FETCH_SOUNDS_SUCCESS:
       return action.queryID;
     case UPDATE_MAP_POSITION: {

--- a/src/containers/Spaces/utils.js
+++ b/src/containers/Spaces/utils.js
@@ -74,13 +74,9 @@ export const computeSpaceIndex = (spaces) => {
   return spaceIndex;
 };
 
-export const getCurrentSpaceObj = function(spaces, queryID) {
-  let currentSpace = {};
-  for (const space of spaces) {
-    if (space.queryID === queryID) {
-      currentSpace = space;
-    }
-  }
+export const getCurrentSpaceObj = (spaces, queryID) => {
+  const currentSpace = spaces.find(space =>
+    space.queryID === queryID);
   return currentSpace;
 };
 


### PR DESCRIPTION
This adds the possibility to abort a running search by deleting the corresponding space.

Only in case of a running search being the currentSpace, the keydown event of esc will remove the corresponding space.

With two simple tests.

Addresses #63 